### PR TITLE
GH-40 Add simple duration util

### DIFF
--- a/eternalcode-commons-shared/src/main/java/com/eternalcode/commons/time/SimpleDurationUtil.java
+++ b/eternalcode-commons-shared/src/main/java/com/eternalcode/commons/time/SimpleDurationUtil.java
@@ -1,0 +1,48 @@
+package com.eternalcode.commons.time;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+public class SimpleDurationUtil {
+
+    private static final Duration ONE_SECOND = Duration.ofSeconds(1);
+    private static final String ZERO_SECONDS = "0s";
+
+    private static final TemporalAmountParser<Duration> WITHOUT_MILLIS_FORMAT = new DurationParser()
+        .withUnit("s", ChronoUnit.SECONDS)
+        .withUnit("m", ChronoUnit.MINUTES)
+        .withUnit("h", ChronoUnit.HOURS)
+        .withUnit("d", ChronoUnit.DAYS)
+        .withUnit("w", ChronoUnit.WEEKS)
+        .withUnit("mo", ChronoUnit.MONTHS)
+        .withUnit("y", ChronoUnit.YEARS)
+        .roundOff(ChronoUnit.MILLIS);
+
+    private static final TemporalAmountParser<Duration> STANDARD_FORMAT = new DurationParser()
+        .withUnit("ms", ChronoUnit.MILLIS)
+        .withUnit("s", ChronoUnit.SECONDS)
+        .withUnit("m", ChronoUnit.MINUTES)
+        .withUnit("h", ChronoUnit.HOURS)
+        .withUnit("d", ChronoUnit.DAYS)
+        .withUnit("w", ChronoUnit.WEEKS)
+        .withUnit("mo", ChronoUnit.MONTHS)
+        .withUnit("y", ChronoUnit.YEARS);
+
+    public static String format(Duration duration, boolean removeMillis) {
+        if (removeMillis) {
+            if (duration.toMillis() < ONE_SECOND.toMillis()) {
+                return "0s";
+            }
+
+            return WITHOUT_MILLIS_FORMAT.format(duration);
+        }
+
+        return STANDARD_FORMAT.format(duration);
+    }
+
+    public static String format(Duration duration) {
+        return format(duration, false);
+    }
+
+
+}

--- a/eternalcode-commons-shared/src/main/java/com/eternalcode/commons/time/SimpleDurationUtil.java
+++ b/eternalcode-commons-shared/src/main/java/com/eternalcode/commons/time/SimpleDurationUtil.java
@@ -31,7 +31,7 @@ public class SimpleDurationUtil {
     public static String format(Duration duration, boolean removeMillis) {
         if (removeMillis) {
             if (duration.toMillis() < ONE_SECOND.toMillis()) {
-                return "0s";
+                return ZERO_SECONDS;
             }
 
             return WITHOUT_MILLIS_FORMAT.format(duration);

--- a/eternalcode-commons-shared/test/com/eternalcode/commons/time/SimpleDurationUtilTest.java
+++ b/eternalcode-commons-shared/test/com/eternalcode/commons/time/SimpleDurationUtilTest.java
@@ -1,0 +1,89 @@
+package com.eternalcode.commons.time;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class SimpleDurationUtilTest {
+
+    @Test
+    public void testFormatWithoutMillis() {
+        Duration duration = Duration.ofMillis(500);
+        String result = SimpleDurationUtil.format(duration, true);
+        assertEquals("0s", result);
+
+        duration = Duration.ofSeconds(30);
+        result = SimpleDurationUtil.format(duration, true);
+        assertEquals("30s", result);
+
+        duration = Duration.ofMinutes(5);
+        result = SimpleDurationUtil.format(duration, true);
+        assertEquals("5m", result);
+
+        duration = Duration.ofHours(2);
+        result = SimpleDurationUtil.format(duration, true);
+        assertEquals("2h", result);
+
+        duration = Duration.ofDays(1);
+        result = SimpleDurationUtil.format(duration, true);
+        assertEquals("1d", result);
+
+        duration = Duration.ofDays(14);
+        result = SimpleDurationUtil.format(duration, true);
+        assertEquals("2w", result);
+
+        duration = Duration.ofDays(60);
+        result = SimpleDurationUtil.format(duration, true);
+        assertEquals("2mo", result);
+
+        duration = Duration.ofDays(365 * 3);
+        result = SimpleDurationUtil.format(duration, true);
+        assertEquals("3y", result);
+    }
+
+    @Test
+    public void testFormatWithMillis() {
+        Duration duration = Duration.ofMillis(500);
+        String result = SimpleDurationUtil.format(duration, false);
+        assertEquals("500ms", result);
+
+        duration = Duration.ofSeconds(30);
+        result = SimpleDurationUtil.format(duration, false);
+        assertEquals("30s", result);
+
+        duration = Duration.ofMinutes(5);
+        result = SimpleDurationUtil.format(duration, false);
+        assertEquals("5m", result);
+
+        duration = Duration.ofHours(2);
+        result = SimpleDurationUtil.format(duration, false);
+        assertEquals("2h", result);
+
+        duration = Duration.ofDays(1);
+        result = SimpleDurationUtil.format(duration, false);
+        assertEquals("1d", result);
+
+        duration = Duration.ofDays(14);
+        result = SimpleDurationUtil.format(duration, false);
+        assertEquals("2w", result);
+
+        duration = Duration.ofDays(60);
+        result = SimpleDurationUtil.format(duration, false);
+        assertEquals("2mo", result);
+
+        duration = Duration.ofDays(365 * 3);
+        result = SimpleDurationUtil.format(duration, false);
+        assertEquals("3y", result);
+    }
+
+    @Test
+    public void testFormatDefault() {
+        Duration duration = Duration.ofSeconds(610);
+        String result = SimpleDurationUtil.format(duration);
+        assertEquals("10m10s", result);
+
+        duration = Duration.ofMillis(120);
+        result = SimpleDurationUtil.format(duration);
+        assertEquals("120ms", result);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `SimpleDurationUtil` class for formatting `Duration` objects in Java.
	- Added methods for flexible duration formatting, with options to include or exclude milliseconds.

- **Tests**
	- Implemented unit tests for `SimpleDurationUtil` to ensure accurate formatting of durations under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->